### PR TITLE
SharedAccessAuthorizationRuleProperties - rights marked as required

### DIFF
--- a/arm-eventhub/2015-08-01/swagger/EventHub.json
+++ b/arm-eventhub/2015-08-01/swagger/EventHub.json
@@ -1490,9 +1490,6 @@
           "$ref": "#/definitions/SharedAccessAuthorizationRuleProperties"
         }
       },
-      "required": [
-        "properties"
-      ],
       "description": "Parameters supplied to the CreateOrUpdate  AuthorizationRules."
     },
     "SharedAccessAuthorizationRuleListResult": {
@@ -1544,6 +1541,9 @@
           "description": "The rights associated with the rule."
         }
       },
+      "required": [
+        "rights"
+      ],
       "description": "SharedAccessAuthorizationRule properties."
     },
     "ResourceListKeys": {

--- a/arm-servicebus/2015-08-01/swagger/servicebus.json
+++ b/arm-servicebus/2015-08-01/swagger/servicebus.json
@@ -2066,9 +2066,6 @@
           "$ref": "#/definitions/SharedAccessAuthorizationRuleProperties"
         }
       },
-      "required": [
-        "properties"
-      ],
       "description": "Parameters supplied to the CreateOrUpdate  AuthorizationRules."
     },
     "SharedAccessAuthorizationRuleListResult": {
@@ -2120,6 +2117,9 @@
           "description": "The rights associated with the rule."
         }
       },
+      "required": [
+        "rights"
+      ],
       "description": "SharedAccessAuthorizationRule properties."
     },
     "ResourceListKeys": {


### PR DESCRIPTION
SharedAccessAuthorizationRuleProperties - rights marked as required instead of properties from SharedAccessAuthorizationRuleResource
